### PR TITLE
Enable FilteredKNN two‑stage classifier

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -27,6 +27,8 @@ class Settings(BaseSettings):
 
     # Настройки классификации
     KNN_NEIGHBORS: int = 5
+    RERANKER_MODEL: str = "BAAI/bge-reranker-large"
+    RERANK_THRESHOLD: float = 0.2
 
     class Config:
         env_file = ".env"

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -18,7 +18,11 @@ async def predict(
         [request.subject], [request.description]
     )
 
-    # Получаем предсказания
-    predictions = classifier.predict(combined_embedding[0])
+    # Получаем предсказания с учетом текстов для двухуровневого классификатора
+    predictions = classifier.predict(
+        request.subject,
+        request.description,
+        combined_embedding[0],
+    )
 
     return PredictionResponse(predictions=predictions)

--- a/backend/services/classification.py
+++ b/backend/services/classification.py
@@ -1,37 +1,105 @@
+import logging
 from collections import Counter
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List
 
 import numpy as np
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
 from config import settings
 from services.vector_db import vector_db
 
+logger = logging.getLogger("classification_service")
 
-class ClassificationService:
-    def __init__(self):
+
+class FilteredKNNClassificationService:
+    """Two-stage classifier using KNN search in Qdrant and reranker filtering."""
+
+    def __init__(self) -> None:
         self.k = settings.KNN_NEIGHBORS
+        self.threshold = settings.RERANK_THRESHOLD
+        self.device = settings.DEVICE
 
-    def predict(self, query_vector: np.ndarray) -> List[Dict[str, float]]:
-        """
-        Предсказывает класс на основе K ближайших соседей
-        """
-        # Получаем K ближайших соседей из Qdrant
+        logger.info(
+            "Loading reranker model %s on %s", settings.RERANKER_MODEL, self.device
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(settings.RERANKER_MODEL)
+        self.model = (
+            AutoModelForSequenceClassification.from_pretrained(settings.RERANKER_MODEL)
+            .to(self.device)
+        )
+        self.model.eval()
+
+    def _rerank_scores(self, query: str, docs: List[str]) -> List[float]:
+        """Computes reranker scores for a query and list of documents."""
+        pairs = [(query, doc) for doc in docs]
+        encoded = self.tokenizer.batch_encode_plus(
+            pairs,
+            padding=True,
+            truncation=True,
+            max_length=settings.MAX_LENGTH,
+            return_tensors="pt",
+        ).to(self.device)
+
+        with torch.no_grad():
+            logits = self.model(**encoded).logits.cpu().numpy()
+
+        if logits.shape[1] == 2:
+            exp = np.exp(logits)
+            probs = exp[:, 1] / exp.sum(axis=1)
+            return probs.tolist()
+        return logits[:, 0].tolist()
+
+    def predict(
+        self, subject: str, description: str, query_vector: np.ndarray
+    ) -> List[Dict[str, float]]:
+        """Return class probabilities for the provided query."""
+        query_text = f"{subject} {description}"
+
+        # Search in vector database
         neighbors = vector_db.search_vectors(query_vector, limit=self.k)
 
-        # Извлекаем классы соседей
-        neighbor_classes = [neighbor["class_name"] for neighbor in neighbors]
+        if not neighbors:
+            logger.warning("No neighbors found in vector DB")
+            return []
 
-        # Считаем частоту каждого класса
-        class_counts = Counter(neighbor_classes)
-        total = sum(class_counts.values())
+        neighbor_texts = [n.get("subject", "") + " " + n.get("description", "") for n in neighbors]
+        neighbor_labels = [n.get("class_name", "") for n in neighbors]
+        sims = [float(n.get("score", 0.0)) for n in neighbors]
 
-        # Вычисляем вероятности классов
-        predictions = [
-            {"class_name": class_name, "probability": count / total}
-            for class_name, count in class_counts.most_common()
-        ]
+        scores = self._rerank_scores(query_text, neighbor_texts)
+        kept_indices = [i for i, s in enumerate(scores) if s >= self.threshold]
+
+        def _aggregate(indices: List[int]) -> List[Dict[str, float]]:
+            class_scores: Dict[str, float] = {}
+            total_sim = 0.0
+            for i in indices:
+                lbl = neighbor_labels[i]
+                sim = sims[i]
+                class_scores[lbl] = class_scores.get(lbl, 0.0) + sim
+                total_sim += sim
+
+            if total_sim <= 1e-12:
+                counts = Counter([neighbor_labels[i] for i in indices])
+                total = sum(counts.values())
+                return [
+                    {"class_name": lbl, "probability": cnt / total}
+                    for lbl, cnt in counts.most_common()
+                ]
+
+            return [
+                {"class_name": lbl, "probability": score / total_sim}
+                for lbl, score in sorted(class_scores.items(), key=lambda x: x[1], reverse=True)
+            ]
+
+        if kept_indices:
+            predictions = _aggregate(kept_indices)
+        else:
+            # fallback to using all neighbors
+            predictions = _aggregate(list(range(len(neighbors))))
 
         return predictions
 
 
-# Создаем синглтон для классификации
-classifier = ClassificationService()
+# Singleton instance
+classifier = FilteredKNNClassificationService()


### PR DESCRIPTION
## Summary
- add reranker model and threshold to settings
- implement `FilteredKNNClassificationService` with reranker-based filtering
- pass subject and description to classifier from predict API

## Testing
- `python -m py_compile backend/config.py backend/services/classification.py backend/routers/predict.py`

------
https://chatgpt.com/codex/tasks/task_e_6840cf26fc388332880ad5654dc87e4d