### PR TITLE
Enable multi collection support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -30,7 +30,7 @@ app.include_router(search.router)
 
 @app.on_event("startup")
 async def startup_event():
-    vector_db.init_collection()
+    vector_db.init_collection(vector_db.collection_name)
 
 
 if __name__ == "__main__":

--- a/backend/models/request_models.py
+++ b/backend/models/request_models.py
@@ -10,6 +10,7 @@ class RequestItem(BaseModel):
     class_name: Optional[str] = Field(
         None, description="Класс обращения (если известен)"
     )
+    collection: Optional[str] = Field(None, description="Имя коллекции Qdrant")
     task: Optional[str] = Field(None, description="Задача обращения (если известна)")
 
     class Config:
@@ -26,6 +27,7 @@ class RequestItem(BaseModel):
 
 class BatchRequestItem(BaseModel):
     items: List[RequestItem] = Field(..., description="Список обращений для обработки")
+    collection: Optional[str] = Field(None, description="Имя коллекции Qdrant для загрузки")
 
     class Config:
         schema_extra = {
@@ -87,6 +89,7 @@ class SearchRequest(BaseModel):
     subject: str = Field("", description="Тема для поиска")
     description: str = Field("", description="Описание для поиска")
     limit: int = Field(10, description="Количество результатов")
+    collection: Optional[str] = Field(None, description="Имя коллекции Qdrant для поиска")
 
 
 class SearchResult(BaseModel):
@@ -115,3 +118,7 @@ class SearchResponse(BaseModel):
                 ]
             }
         }
+
+class CollectionRequest(BaseModel):
+    collection: Optional[str] = Field(None, description="Имя коллекции Qdrant")
+

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -23,6 +23,7 @@ async def predict(
         request.subject,
         request.description,
         combined_embedding[0],
+        collection_name=request.collection
     )
 
     return PredictionResponse(predictions=predictions)

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -22,7 +22,7 @@ async def search(
     query_embedding = np.concatenate([subject_embedding, description_embedding])
 
     # Ищем похожие векторы
-    search_results = vector_db.search_vectors(query_embedding, limit=request.limit)
+    search_results = vector_db.search_vectors(query_embedding, limit=request.limit, collection_name=request.collection)
 
     # Форматируем результаты
     results = [

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -7,7 +7,7 @@ from services.embedding import embedder
 from services.vector_db import vector_db
 
 from models.auth import User
-from models.request_models import BatchRequestItem, UploadResponse
+from models.request_models import BatchRequestItem, UploadResponse, CollectionRequest
 
 # Добавляем логгер
 logger = logging.getLogger("upload_router")
@@ -46,7 +46,7 @@ async def upload_data(
 
     # Загружаем векторы в Qdrant
     try:
-        ids = vector_db.upload_vectors(combined_embeddings, payloads)
+        ids = vector_db.upload_vectors(combined_embeddings, payloads, collection_name=request.collection)
         return UploadResponse(success=True, message="Данные успешно загружены", ids=ids)
     except Exception as e:
         logger.error(f"Error uploading vectors: {str(e)}")
@@ -55,9 +55,9 @@ async def upload_data(
         )
 
 @router.post("/clear_index", response_model=UploadResponse)
-async def clear_index(current_user: User = Depends(get_current_active_user)):
+async def clear_index(request: CollectionRequest = None, current_user: User = Depends(get_current_active_user)):
     try:
-        vector_db.clear_collection()
+        vector_db.clear_collection(collection_name=request.collection if request else None)
         return UploadResponse(success=True, message="Индекс успешно очищен", ids=[])
     except Exception as e:
         logger.error(f"Error clearing index: {str(e)}")

--- a/backend/services/classification.py
+++ b/backend/services/classification.py
@@ -51,13 +51,13 @@ class FilteredKNNClassificationService:
         return logits[:, 0].tolist()
 
     def predict(
-        self, subject: str, description: str, query_vector: np.ndarray
+        self, subject: str, description: str, query_vector: np.ndarray, collection_name: Optional[str] = None
     ) -> List[Dict[str, float]]:
         """Return class probabilities for the provided query."""
         query_text = f"{subject} {description}"
 
         # Search in vector database
-        neighbors = vector_db.search_vectors(query_vector, limit=self.k)
+        neighbors = vector_db.search_vectors(query_vector, limit=self.k, collection_name=collection_name)
 
         if not neighbors:
             logger.warning("No neighbors found in vector DB")


### PR DESCRIPTION
## Summary
- allow choosing Qdrant collection for searches, predictions and uploads
- add optional `collection` field to API models
- propagate collection parameter through routers and services
- fix missing parenthesis, docstring typo and return value after review

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840d8299a9c8332ad1e143d246c773f