### PR TITLE
Add test collection support

### DIFF
--- a/backend/models/request_models.py
+++ b/backend/models/request_models.py
@@ -122,3 +122,10 @@ class SearchResponse(BaseModel):
 class CollectionRequest(BaseModel):
     collection: Optional[str] = Field(None, description="Имя коллекции Qdrant")
 
+
+class CopyCollectionRequest(BaseModel):
+    source: str = Field(..., description="Имя коллекции-источника")
+    dest: Optional[str] = Field(
+        None, description="Имя целевой коллекции (по умолчанию основная)"
+    )
+

--- a/backend/services/vector_db.py
+++ b/backend/services/vector_db.py
@@ -185,6 +185,20 @@ class VectorDBService:
             logger.error(f"Error clearing collection: {str(e)}")
             raise
 
+    def copy_collection(self, source: str, dest: Optional[str] = None) -> None:
+        """Copy all data from source collection to destination."""
+        dst = dest or self.collection_name
+        logger.info(f"Copying collection {source} -> {dst}")
+        self.client.recreate_collection(
+            collection_name=dst,
+            vectors_config=models.VectorParams(
+                size=self.vector_size,
+                distance=models.Distance.COSINE,
+            ),
+            init_from=models.InitFrom(collection=source),
+        )
+        logger.info("Collection copy finished")
+
 
 
 # Создаем синглтон для переиспользования клиента Qdrant

--- a/frontend/config.py
+++ b/frontend/config.py
@@ -5,6 +5,9 @@ API_URL = os.getenv("API_URL", "http://localhost:8190")
 USERNAME = os.getenv("USERNAME", "admin") 
 PASSWORD = os.getenv("PASSWORD", "secret")
 
+# Имя коллекции по умолчанию для тестового стенда
+TEST_COLLECTION = os.getenv("TEST_COLLECTION", "test_requests")
+
 # Примеры запросов для выбора
 DEFAULT_EXAMPLES = [
     {

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -4,6 +4,7 @@ from config import API_URL, USERNAME, PASSWORD
 from tab_classification import render_classification_tab
 from tab_similar_docs import render_similar_docs_tab
 from tab_data_upload import render_data_upload_tab
+from tab_test_env import render_test_env_tab
 
 # Page configuration
 st.set_page_config(
@@ -28,7 +29,12 @@ with st.sidebar:
         st.success("Settings saved")
 
 # Create tabs
-tab1, tab2, tab3 = st.tabs(["Classification", "Similar Documents", "Data Upload"])
+tab1, tab2, tab3, tab4 = st.tabs([
+    "Classification",
+    "Similar Documents",
+    "Data Upload",
+    "Test Stand",
+])
 
 # Tab 1: Classification
 with tab1:
@@ -41,3 +47,7 @@ with tab2:
 # Tab 3: Data Upload and Evaluation
 with tab3:
     render_data_upload_tab(api_url, username, password)
+
+# Tab 4: Test Stand
+with tab4:
+    render_test_env_tab(api_url, username, password)

--- a/frontend/tab_classification.py
+++ b/frontend/tab_classification.py
@@ -56,37 +56,37 @@ def render_classification_tab(api_url, username, password):
 
             if token:
                 with st.spinner("Classifying request..."):
-                    result = classify_request(subject, description, token, api_url)
+                    prod_result = classify_request(subject, description, token, api_url)
+                    test_collection = st.session_state.get("test_collection")
+                    test_result = None
+                    if test_collection:
+                        test_result = classify_request(
+                            subject, description, token, api_url, collection=test_collection
+                        )
 
-                if result and "predictions" in result:
+                if prod_result and "predictions" in prod_result:
                     st.success("Request successfully classified!")
 
-                    # Show results as a table
-                    predictions_df = pd.DataFrame(result["predictions"])
-                    st.subheader("Classification Results:")
-                    st.dataframe(predictions_df, width=800)
+                    col1, col2 = st.columns(2)
+                    with col1:
+                        predictions_df = pd.DataFrame(prod_result["predictions"])
+                        st.subheader("Production Results:")
+                        st.dataframe(predictions_df, width=400)
+                        st.write(
+                            f"Predicted: {prod_result['predictions'][0]['class_name']} "
+                            f"({prod_result['predictions'][0]['probability']:.2f})"
+                        )
 
-                    # Visualize probabilities
-                    fig, ax = plt.subplots(figsize=(10, 5))
-                    sns.barplot(
-                        x="class_name",
-                        y="probability",
-                        data=predictions_df.head(5),
-                        ax=ax,
-                    )
-                    ax.set_xlabel("Class")
-                    ax.set_ylabel("Probability")
-                    ax.set_title("Top 5 Classes by Probability")
-                    plt.xticks(rotation=45, ha="right")
-                    plt.tight_layout()
-                    st.pyplot(fig)
-
-                    # Show the predicted class
-                    st.subheader(
-                        f"Predicted Class: {result['predictions'][0]['class_name']}"
-                    )
-                    st.subheader(
-                        f"Probability: {result['predictions'][0]['probability']:.2f}"
-                    )
+                    if test_result and "predictions" in test_result:
+                        with col2:
+                            test_df = pd.DataFrame(test_result["predictions"])
+                            st.subheader(
+                                f"Test Results ({test_collection})"
+                            )
+                            st.dataframe(test_df, width=400)
+                            st.write(
+                                f"Predicted: {test_result['predictions'][0]['class_name']} "
+                                f"({test_result['predictions'][0]['probability']:.2f})"
+                            )
                 else:
                     st.error("Failed to get classification results")

--- a/frontend/tab_data_upload.py
+++ b/frontend/tab_data_upload.py
@@ -8,13 +8,16 @@ from datetime import datetime
 
 from api_utils import get_token, clear_index, upload_data, predict, accuracy_score, train_test_split, classification_report, confusion_matrix, filter_high_quality_classes
 
-def render_data_upload_tab(api_url, username, password):
+def render_data_upload_tab(api_url, username, password, collection=None):
     """Display the Data Upload and Quality Evaluation tab"""
-    st.title("Data Upload and Quality Evaluation")
+    title = "Data Upload and Quality Evaluation"
+    if collection:
+        title += f" ({collection})"
+    st.title(title)
     
     # Create directories for saving files and metrics if they don't exist
     data_dir = "uploaded_data"
-    metrics_dir = "metrics"
+    metrics_dir = os.path.join("metrics", collection or "prod")
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
     if not os.path.exists(metrics_dir):
@@ -218,14 +221,14 @@ def render_data_upload_tab(api_url, username, password):
                     with st.spinner("Uploading data to the system..."):
                         if clear_index_flag:
                             st.info("Clearing existing index...")
-                            clear_index(token, api_url)
-                        
-                        upload_data(train_df, token, api_url)
+                            clear_index(token, api_url, collection)
+
+                        upload_data(train_df, token, api_url, collection)
                     
                     st.success("Data uploaded successfully")
                     
                     with st.spinner("Getting predictions for the test set..."):
-                        preds = predict(test_df, token, api_url)
+                        preds = predict(test_df, token, api_url, collection)
                     
                     # Calculate metrics
                     y_true = test_df["class"].tolist()
@@ -326,7 +329,12 @@ def render_data_upload_tab(api_url, username, password):
                         
                         if upload_test_data:
                             with st.spinner("Uploading test set to the system..."):
-                                test_upload_result = upload_data(test_df, token, api_url)
+                                test_upload_result = upload_data(
+                                    test_df,
+                                    token,
+                                    api_url,
+                                    collection,
+                                )
                                 if test_upload_result:
                                     st.success(f"Test set uploaded successfully ({len(test_df)} records)")
                                 else:

--- a/frontend/tab_test_env.py
+++ b/frontend/tab_test_env.py
@@ -1,0 +1,39 @@
+import streamlit as st
+from api_utils import get_token, create_collection, copy_collection
+from tab_data_upload import render_data_upload_tab
+from config import TEST_COLLECTION
+
+def render_test_env_tab(api_url, username, password):
+    st.title("Test Environment")
+
+    # Get collection name from session or use default
+    default_name = st.session_state.get("test_collection", TEST_COLLECTION)
+    collection_name = st.text_input("Test collection name", value=default_name)
+
+    if "test_collection" not in st.session_state:
+        st.session_state["test_collection"] = default_name
+        token = get_token(api_url, username, password)
+        if token:
+            create_collection(token, api_url, default_name)
+
+    if st.button("Save name"):
+        st.session_state["test_collection"] = collection_name
+        token = get_token(api_url, username, password)
+        if token:
+            create_collection(token, api_url, collection_name)
+        st.success(f"Test collection set to {collection_name}")
+
+    st.info(
+        f"Current test collection: {st.session_state.get('test_collection', collection_name)}"
+    )
+
+    st.divider()
+
+    render_data_upload_tab(
+        api_url, username, password, collection=st.session_state["test_collection"]
+    )
+
+    if st.button("Promote test to production"):
+        token = get_token(api_url, username, password)
+        if token:
+            copy_collection(token, api_url, st.session_state["test_collection"])


### PR DESCRIPTION
## Summary
- implement copying and creation of collections in backend
- add API endpoints to manage collections
- extend frontend API utils for test collections
- add test environment tab in Streamlit UI
- show prod vs test results in classification and search tabs
- enable uploading & evaluating data for a custom collection
- use default test collection name and streamline promotion flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421ad979488332b836ebc19cc076b7