### PR TITLE
Implement test index support

### DIFF
--- a/frontend/tab_classification.py
+++ b/frontend/tab_classification.py
@@ -1,10 +1,22 @@
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
 import streamlit as st
 
 from api_utils import get_token, classify_request
 from config import DEFAULT_EXAMPLES
+
+
+def _show_predictions(title: str, predictions: list) -> None:
+    """Render predictions inside an expander."""
+    if not predictions:
+        st.warning("No predictions returned")
+        return
+    with st.expander(title, expanded=True):
+        df = pd.DataFrame(predictions)
+        st.dataframe(df, use_container_width=True)
+        st.write(
+            f"Predicted: {predictions[0]['class_name']} "
+            f"({predictions[0]['probability']:.2f})"
+        )
 
 def render_classification_tab(api_url, username, password):
     """Display the classification tab"""
@@ -66,27 +78,11 @@ def render_classification_tab(api_url, username, password):
 
                 if prod_result and "predictions" in prod_result:
                     st.success("Request successfully classified!")
-
-                    col1, col2 = st.columns(2)
-                    with col1:
-                        predictions_df = pd.DataFrame(prod_result["predictions"])
-                        st.subheader("Production Results:")
-                        st.dataframe(predictions_df, width=400)
-                        st.write(
-                            f"Predicted: {prod_result['predictions'][0]['class_name']} "
-                            f"({prod_result['predictions'][0]['probability']:.2f})"
-                        )
-
+                    _show_predictions("Production Results", prod_result["predictions"])
                     if test_result and "predictions" in test_result:
-                        with col2:
-                            test_df = pd.DataFrame(test_result["predictions"])
-                            st.subheader(
-                                f"Test Results ({test_collection})"
-                            )
-                            st.dataframe(test_df, width=400)
-                            st.write(
-                                f"Predicted: {test_result['predictions'][0]['class_name']} "
-                                f"({test_result['predictions'][0]['probability']:.2f})"
-                            )
+                        _show_predictions(
+                            f"Test Results ({test_collection})",
+                            test_result["predictions"],
+                        )
                 else:
                     st.error("Failed to get classification results")

--- a/frontend/tab_test_env.py
+++ b/frontend/tab_test_env.py
@@ -1,9 +1,27 @@
+import os
+import shutil
 import streamlit as st
-from api_utils import get_token, create_collection, copy_collection
+from api_utils import get_token, copy_collection
 from tab_data_upload import render_data_upload_tab
 from config import TEST_COLLECTION
 
+
+def _copy_latest_metrics(collection: str) -> None:
+    """Copy latest metrics from test collection to production."""
+    src_dir = os.path.join("metrics", collection)
+    dst_dir = os.path.join("metrics", "prod")
+    if not os.path.isdir(src_dir):
+        return
+    files = [f for f in os.listdir(src_dir) if f.startswith("metrics_") and f.endswith(".json")]
+    if not files:
+        return
+    files.sort(reverse=True)
+    os.makedirs(dst_dir, exist_ok=True)
+    shutil.copy(os.path.join(src_dir, files[0]), os.path.join(dst_dir, files[0]))
+
 def render_test_env_tab(api_url, username, password):
+    if "test_collection" not in st.session_state:
+        st.session_state["test_collection"] = TEST_COLLECTION
 
     render_data_upload_tab(
         api_url, username, password, collection=TEST_COLLECTION
@@ -13,3 +31,4 @@ def render_test_env_tab(api_url, username, password):
         token = get_token(api_url, username, password)
         if token:
             copy_collection(token, api_url, TEST_COLLECTION)
+            _copy_latest_metrics(TEST_COLLECTION)


### PR DESCRIPTION
## Summary
- add helper functions for rendering results in classification/search
- use expanders for prod vs test results
- promote test metrics to prod when copying collection
- set test collection session variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470c99866c8332b5999a276295a68f