### PR TITLE
Update frontend to display prod and test results

### DIFF
--- a/frontend/main.py
+++ b/frontend/main.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from config import API_URL, USERNAME, PASSWORD
+from config import API_URL, USERNAME, PASSWORD, TEST_COLLECTION
 from tab_classification import render_classification_tab
 from tab_similar_docs import render_similar_docs_tab
 from tab_data_upload import render_data_upload_tab
@@ -24,8 +24,13 @@ with st.sidebar:
     st.title("API Settings")
     username = st.text_input("Username")
     password = st.text_input("Password", type="password")
+    test_collection = st.text_input(
+        "Test Collection",
+        value=st.session_state.get("test_collection", TEST_COLLECTION),
+    )
 
     if st.button("Save Settings"):
+        st.session_state["test_collection"] = test_collection
         st.success("Settings saved")
 
 # Create tabs

--- a/frontend/tab_classification.py
+++ b/frontend/tab_classification.py
@@ -78,11 +78,22 @@ def render_classification_tab(api_url, username, password):
 
                 if prod_result and "predictions" in prod_result:
                     st.success("Request successfully classified!")
-                    _show_predictions("Production Results", prod_result["predictions"])
                     if test_result and "predictions" in test_result:
+                        col1, col2 = st.columns(2)
+                        with col1:
+                            _show_predictions(
+                                "Production Results",
+                                prod_result["predictions"],
+                            )
+                        with col2:
+                            _show_predictions(
+                                f"Test Results ({test_collection})",
+                                test_result["predictions"],
+                            )
+                    else:
                         _show_predictions(
-                            f"Test Results ({test_collection})",
-                            test_result["predictions"],
+                            "Production Results",
+                            prod_result["predictions"],
                         )
                 else:
                     st.error("Failed to get classification results")

--- a/frontend/tab_similar_docs.py
+++ b/frontend/tab_similar_docs.py
@@ -132,12 +132,22 @@ def render_similar_docs_tab(api_url, username, password):
                         use_container_width=True,
                     )
 
-                    _show_search_results("Production Results", search_results["results"])
-
                     if test_results and "results" in test_results:
+                        col1, col2 = st.columns(2)
+                        with col1:
+                            _show_search_results(
+                                "Production Results",
+                                search_results["results"],
+                            )
+                        with col2:
+                            _show_search_results(
+                                f"Test Results ({test_collection})",
+                                test_results["results"],
+                            )
+                    else:
                         _show_search_results(
-                            f"Test Results ({test_collection})",
-                            test_results["results"],
+                            "Production Results",
+                            search_results["results"],
                         )
 
                 else:


### PR DESCRIPTION
## Summary
- add test collection field in sidebar
- show production and test results side-by-side in classification and search tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847198f08a0833296d7a8086030e9bc